### PR TITLE
feat: Implement a better proxy and use cache to speed up rendering

### DIFF
--- a/src/lib/supabase/client.js
+++ b/src/lib/supabase/client.js
@@ -1,8 +1,9 @@
 import { createBrowserClient } from "@supabase/ssr";
+import { cache } from "react";
 
-export async function createClient() {
+export const createClient = cache(() => {
     return createBrowserClient(
         process.env.NEXT_PUBLIC_SUPABASE_URL,
         process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
     );
-}
+});

--- a/src/lib/supabase/server.js
+++ b/src/lib/supabase/server.js
@@ -1,7 +1,9 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
+import { cache } from "react";
 
-export async function createClient() {
+
+export const createClient = cache(async () => {
     const cookieStore = await cookies();
 
     return createServerClient(
@@ -22,4 +24,4 @@ export async function createClient() {
         },
         }
     );
-}
+});

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -10,6 +10,19 @@ export async function proxy(request) {
         return NextResponse.next();
     }
 
+    const cookies = request.cookies.getAll();
+    const hasSessionCookie = cookies.some((c) => c.name.startsWith('sb-'));
+
+    if (!hasSessionCookie && request.nextUrl.pathname.startsWith("/dashboard")) {
+        const url = request.nextUrl.clone();
+        url.pathname = "/";
+        return NextResponse.redirect(url);
+    }
+
+    if (!hasSessionCookie && request.nextUrl.pathname === "/") {
+        return NextResponse.next();
+    }
+
     let response = NextResponse.next({
         request: {
             headers: request.headers,
@@ -21,16 +34,12 @@ export async function proxy(request) {
         process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
         {
             cookies: {
-                getAll() {
-                    return request.cookies.getAll();
-                },
+                getAll() { return request.cookies.getAll(); },
                 setAll(cookiesToSet) {
                     cookiesToSet.forEach(({ name, value }) =>
                         request.cookies.set(name, value),
                     );
-
                     response = NextResponse.next({ request });
-
                     cookiesToSet.forEach(({ name, value, options }) =>
                         response.cookies.set(name, value, options),
                     );


### PR DESCRIPTION
For some reason, the app is experiencing a very noticeable delay. In this implementation, the `proxy.js`, which is probably the main culprit, was revised to lessen the check to the database, but instead to check if the browser still contains the auth cookies to indicate that the user is authenticated. Additionally, addresses the issue with Vercel and Supabase having a different region, they are now pointing at the same region `(Seoul, South Korea)`.